### PR TITLE
Fix wrong indentation of classic component path

### DIFF
--- a/changelog_unreleased/handlebars/pr-8593.md
+++ b/changelog_unreleased/handlebars/pr-8593.md
@@ -1,0 +1,35 @@
+#### Fix formatting of classic components inside element ([#8593](https://github.com/prettier/prettier/pull/8593) by [@mikoscz](https://github.com/mikoscz)
+
+<!-- prettier-ignore -->
+```hbs
+{{!-- Input --}}
+<div>
+  {{classic-component-with-many-properties
+    class="hello"
+    param=this.someValue
+    secondParam=this.someValue
+    thirdParam=this.someValue
+  }}
+</div>
+
+{{!-- Prettier stable --}}
+<div>
+  {{
+    classic-component-with-many-properties
+    class="hello"
+    param=this.someValue
+    secondParam=this.someValue
+    thirdParam=this.someValue
+  }}
+</div>
+
+{{!-- Prettier master --}}
+<div>
+  {{classic-component-with-many-properties
+    class="hello"
+    param=this.someValue
+    secondParam=this.someValue
+    thirdParam=this.someValue
+  }}
+</div>
+```

--- a/src/language-handlebars/printer-glimmer.js
+++ b/src/language-handlebars/printer-glimmer.js
@@ -115,11 +115,13 @@ function print(path, options, print) {
       );
     }
     case "MustacheStatement": {
-      const shouldBreakOpeningMustache = isParentOfSomeType(path, [
+      const isParentOfSpecifiedTypes = isParentOfSomeType(path, [
         "AttrNode",
         "ConcatStatement",
         "ElementNode",
       ]);
+      const shouldBreakOpeningMustache =
+        isParentOfSpecifiedTypes && doesNotHaveHashParams(n);
 
       return group(
         concat([
@@ -647,6 +649,10 @@ function locationToOffset(source, line, column) {
     seenLines += 1;
     seenChars = nextLine + 1;
   }
+}
+
+function doesNotHaveHashParams(node) {
+  return node.hash.pairs.length === 0;
 }
 
 module.exports = {

--- a/tests/handlebars/mustache-statement/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/handlebars/mustache-statement/__snapshots__/jsfmt.spec.js.snap
@@ -37,18 +37,29 @@ singleQuote: true
 <div
   class="a-first-class
     {{if this.optionOne "optionOne"}}
-    
+
     {{if this.optionTwo "optionTwo"}}
-    
+
     {{if this.optionThree "optionThree"}}
-    
+
     {{if this.optionFour "optionFour"}}
-    
+
     {{if this.optionFive "optionFive"}}
-    
+
     {{this.class}}"
   ...attributes >
 </div>
+
+<div>
+  {{classic-component-with-many-properties
+    class="hello"
+    param=this.someValue
+    secondParam=this.someValue
+    thirdParam=this.someValue
+  }}
+</div>
+
+
 
 =====================================output=====================================
 <GlimmerComponent
@@ -116,6 +127,15 @@ singleQuote: true
   ...attributes
 >
 </div>
+
+<div>
+  {{classic-component-with-many-properties
+    class='hello'
+    param=this.someValue
+    secondParam=this.someValue
+    thirdParam=this.someValue
+  }}
+</div>
 ================================================================================
 `;
 
@@ -155,18 +175,29 @@ printWidth: 80
 <div
   class="a-first-class
     {{if this.optionOne "optionOne"}}
-    
+
     {{if this.optionTwo "optionTwo"}}
-    
+
     {{if this.optionThree "optionThree"}}
-    
+
     {{if this.optionFour "optionFour"}}
-    
+
     {{if this.optionFive "optionFive"}}
-    
+
     {{this.class}}"
   ...attributes >
 </div>
+
+<div>
+  {{classic-component-with-many-properties
+    class="hello"
+    param=this.someValue
+    secondParam=this.someValue
+    thirdParam=this.someValue
+  }}
+</div>
+
+
 
 =====================================output=====================================
 <GlimmerComponent
@@ -233,6 +264,15 @@ printWidth: 80
    {{this.class}}"
   ...attributes
 >
+</div>
+
+<div>
+  {{classic-component-with-many-properties
+    class="hello"
+    param=this.someValue
+    secondParam=this.someValue
+    thirdParam=this.someValue
+  }}
 </div>
 ================================================================================
 `;

--- a/tests/handlebars/mustache-statement/basics.hbs
+++ b/tests/handlebars/mustache-statement/basics.hbs
@@ -28,15 +28,26 @@
 <div
   class="a-first-class
     {{if this.optionOne "optionOne"}}
-    
+
     {{if this.optionTwo "optionTwo"}}
-    
+
     {{if this.optionThree "optionThree"}}
-    
+
     {{if this.optionFour "optionFour"}}
-    
+
     {{if this.optionFive "optionFive"}}
-    
+
     {{this.class}}"
   ...attributes >
 </div>
+
+<div>
+  {{classic-component-with-many-properties
+    class="hello"
+    param=this.someValue
+    secondParam=this.someValue
+    thirdParam=this.someValue
+  }}
+</div>
+
+


### PR DESCRIPTION
<!-- Please provide a brief summary of your changes: -->

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory)
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/pr-XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [ ] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
